### PR TITLE
fix(deps): restore gopher-lua to go.sum, add tidy drift check

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,6 +19,10 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
+    - name: Verify go.mod and go.sum are tidy
+      run: |
+        go mod tidy
+        git diff --exit-code go.mod go.sum
     - name: Run tests
       run: make test
     - name: Run coverage

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/tehcyx/girc
 
 require (
+	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.19.0
 	github.com/sirupsen/logrus v1.9.4
@@ -9,8 +10,8 @@ require (
 )
 
 require (
-	github.com/alicebob/miniredis/v2 v2.37.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=


### PR DESCRIPTION
## Summary
- CI on `master` was failing with `missing go.sum entry for module providing package github.com/yuin/gopher-lua` after Dependabot PR #14 (go-redis 9.19.0).
- `go-redis` bump trimmed indirect entries for `gopher-lua`, but `pkg/server` tests still pull it transitively via `github.com/alicebob/miniredis/v2`.
- `go mod tidy` re-adds the missing entries and promotes `miniredis/v2` from indirect to direct (which it already is in code).
- Added a CI step that runs `go mod tidy` then `git diff --exit-code go.mod go.sum` to catch tidy drift before merge.

## Root cause
PR #14 dropped `github.com/yuin/gopher-lua` from `go.sum` while `miniredis/v2` (used in `pkg/server` tests) still requires it. `go test ./...` fails to load the package.

## Regression test
Verified the new CI step exits 1 on the pre-fix state (gopher-lua missing) and exits 0 after tidy.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — `pkg/server` passes (5.2s)
- [x] `go mod tidy && git diff --exit-code go.mod go.sum` — clean after fix
- [x] Confirmed same check fails on origin/master (catches the regression)

Refs portal#33