### PR TITLE
ci: multi-arch (amd64+arm64) container builds + Dockerfile rewrite

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,20 +34,25 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
     - uses: actions/checkout@v7
+    - uses: docker/setup-qemu-action@v3
+    - uses: docker/setup-buildx-action@v3
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build Docker image
-      run: |
-        make docker
-        docker build -t girc .
-    - name: Tag and push image
-      run: |
-        commit=$(git rev-parse HEAD)
-        docker tag girc:latest ghcr.io/${{ github.repository }}/app:latest
-        docker tag girc:latest "ghcr.io/${{ github.repository }}/app:${commit}"
-        docker push ghcr.io/${{ github.repository }}/app:latest
-        docker push "ghcr.io/${{ github.repository }}/app:${commit}"
+    - uses: docker/metadata-action@v5
+      id: meta
+      with:
+        images: ghcr.io/${{ github.repository }}/app
+        tags: |
+          type=sha,prefix=commit-
+    - uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64,linux/arm64
+        provenance: false

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,7 +34,6 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
     - uses: actions/checkout@v7
-    - uses: docker/setup-qemu-action@v3
     - uses: docker/setup-buildx-action@v3
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
+ARG TARGETOS TARGETARCH
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /app cmd/girc/main.go
+
 FROM scratch
-
-ADD bin/appdocker /
-
-CMD ["/appdocker"]
+COPY --from=build /app /app
+ENTRYPOINT ["/app"]

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -1,8 +1,0 @@
-FROM golang:latest
-WORKDIR /girc
-ADD . /girc
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-s" -a -installsuffix cgo -o bin/appdocker
-
-FROM scratch
-COPY --from=0 /girc/bin/appdocker .
-CMD ["./appdocker"]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ build: test cover
 	go build -ldflags "-X github.com/tehcyx/girc/pkg/version.Version=${VERSION} -X github.com/tehcyx/girc/pkg/version.GitCommit=${GIT_COMMIT}" -o bin/app cmd/girc/main.go
 
 docker:
-	CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/tehcyx/girc/pkg/version.Version=${VERSION} -X github.com/tehcyx/girc/pkg/version.GitCommit=${GIT_COMMIT} -s" -a -installsuffix cgo -o bin/appdocker cmd/girc/main.go
 	docker build -t girc .
 
 run: docker

--- a/go.mod
+++ b/go.mod
@@ -16,4 +16,4 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 )
 
-go 1.25.0
+go 1.26.0


### PR DESCRIPTION
## Summary
- Dockerfile rewritten as multi-stage cross-compile (`FROM --platform=$BUILDPLATFORM golang:1.26-alpine` + `TARGETOS/TARGETARCH`) → `FROM scratch`. Replaces the old `bin/appdocker`-copy pattern.
- `Dockerfile.hub` removed (superseded).
- `master.yml` builds and pushes `linux/amd64,linux/arm64` via `docker/build-push-action@v6` with `provenance: false`. Tag scheme: `commit-<sha>` via `docker/metadata-action@v5`. `:latest` dropped (girc not deployed to any homelab chart — verified).
- `Makefile` `docker` target now `docker build -t girc .` (removed pre-cross-compile).
- `go.mod` bumped 1.25 → 1.26.

Enables scheduling girc on the new arm64 `pi5-worker-01` Talos worker.

Portal: #329

## Test plan
- [ ] CI green
- [ ] `docker buildx imagetools inspect ghcr.io/tehcyx/girc/app:commit-<sha>` shows both `linux/amd64` and `linux/arm64` in the manifest list post-merge
- [ ] `go test ./...` still green post-merge

## Advisory follow-ups (not in this PR)
- Version stamping via `-ldflags` was dropped (previously in `make docker`); image reports v0.1.0 always. Restore via `--build-arg VERSION`/`GIT_COMMIT` in Dockerfile if desired.
- README's "Building for Containers" snippet still shows 1.25 + CMD — refresh separately.
- No `.dockerignore` — minor build-context bloat.
