### PR TITLE
fix(ci): stop the automerge job waiting on its own check

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -14,7 +14,7 @@
 # The wait is explicit instead of using GitHub's auto-merge. Auto-merge only
 # holds a PR back for checks that branch protection marks *required*, and these
 # repos have no branch protection, so it would merge instantly with CI still
-# running. Watching the checks here does the waiting honestly.
+# running. Waiting here does it honestly.
 name: Dependabot auto-merge
 
 on: pull_request_target
@@ -39,21 +39,50 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.html_url }}
+          # This job is itself a check on the PR, so it has to be excluded from
+          # what it waits for. `gh pr checks --watch` does not know that and
+          # blocks on this job's own pending status forever — every other check
+          # green, the PR never merging.
+          SELF: ${{ github.job }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
 
-          # --watch blocks until every check finishes; --fail-fast gives up as
-          # soon as one fails rather than waiting out the rest.
-          if gh pr checks "$PR" --watch --fail-fast --interval 20; then
-            echo "checks passed"
-          elif gh pr checks "$PR" 2>&1 | grep -qi 'no checks reported'; then
-            # Some of these repos run CI only on a schedule, so a PR genuinely
-            # has nothing to wait for. Merging is still right for a patch, but
-            # say so plainly rather than letting it look like checks passed.
-            echo "no checks configured on this repository; merging on the patch-only policy"
-          else
-            echo "checks did not pass; leaving this one for review"
-            exit 1
-          fi
+          deadline=$(( $(date +%s) + 1800 ))
+          while :; do
+            out=$(gh pr checks "$PR" 2>&1) || true
+
+            if printf '%s\n' "$out" | grep -qi 'no checks reported'; then
+              # Some of these repos run CI only on a schedule, so a PR has
+              # genuinely nothing to wait for. Say so rather than letting it
+              # read as though something passed.
+              echo "no checks on this repository; merging on the patch-only policy"
+              break
+            fi
+
+            others=$(printf '%s\n' "$out" | grep -v "^${SELF}[[:space:]]") || true
+            if [ -z "$others" ]; then
+              echo "no checks besides this job; merging on the patch-only policy"
+              break
+            fi
+
+            if printf '%s\n' "$others" | grep -qE '[[:space:]](fail|failure|cancelled|timed_out)([[:space:]]|$)'; then
+              echo "a check did not pass; leaving this one for review"
+              printf '%s\n' "$others"
+              exit 1
+            fi
+
+            if printf '%s\n' "$others" | grep -qE '[[:space:]](pending|queued|in_progress)([[:space:]]|$)'; then
+              if [ "$(date +%s)" -ge "$deadline" ]; then
+                echo "checks still running after 30 minutes; leaving this one for review"
+                exit 1
+              fi
+              sleep 20
+              continue
+            fi
+
+            echo "all checks passed"
+            printf '%s\n' "$others"
+            break
+          done
 
           gh pr merge --squash --delete-branch "$PR"


### PR DESCRIPTION
Portal ticket: #358. Follow-up to the automerge workflow just merged.

## The bug

The `auto-merge` job is itself a check on the PR it is trying to merge, and `gh pr checks --watch` waits for **every** check — including that one. So it waited on itself forever.

Caught live on `lic#13`, which sat in exactly this state:

```
CodeQL=pass  analyze=pass  test=pass  auto-merge=pending
```

Every real check green, the merge never happening.

## The fix

Poll instead of `--watch`, filtering this job out by name (`${{ github.job }}`) before deciding. While rewriting it the loop also gained two things it should have had:

- **failed vs still-running are now distinguished** — a failed check exits immediately rather than being waited on
- **a 30-minute deadline**, so a stuck check leaves the PR for review instead of holding a runner indefinitely

The "no checks at all" case is still handled separately, for the repos whose CI is schedule-only.